### PR TITLE
Rework Cython to avoid duplicated build, include numpy headers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,10 @@ import numpy
 
 sourcefiles = [ 'SuchTree/SuchTree.pyx' ]
 
-extensions = [ Extension( 'SuchTree', sourcefiles ) ]
+extensions = [ Extension( 'SuchTree', sourcefiles, include_dirs=[numpy.get_include()]) ]
 
-extensions = cythonize( extensions, language_level = "3",
-                        include_path = [ numpy.get_include() ] )
+extensions = cythonize( extensions, language_level = "3" )
 
 setup(
-    ext_modules = cythonize( 'SuchTree/SuchTree.pyx' )
+    ext_modules = extensions
 )


### PR DESCRIPTION
This PR fixes up the Cython wrangling in `setup.py` to get past the [failure in CI](https://github.com/ryneches/SuchTree/runs/6767730509?check_suite_focus=true) due to missing `numpy` headers. The package should build now.