### PR TITLE
Rename binary extension to '_SuchTree' to fix circular import problem

### DIFF
--- a/SuchTree/__init__.py
+++ b/SuchTree/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
 from __future__ import absolute_import
-from SuchTree.SuchTree import SuchTree, SuchLinkedTrees
+from _SuchTree import SuchTree, SuchLinkedTrees
 
 __version__ = 0.8

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import numpy
 
 sourcefiles = [ 'SuchTree/SuchTree.pyx' ]
 
-extensions = [ Extension( 'SuchTree', sourcefiles, include_dirs=[numpy.get_include()]) ]
+extensions = [ Extension( '_SuchTree', sourcefiles, include_dirs=[numpy.get_include()]) ]
 
 extensions = cythonize( extensions, language_level = "3" )
 


### PR DESCRIPTION
This PR renames the binary Cython module to `_SuchTree` from `SuchTree` to avoid circular references when importing the things it implements in the `SuchTree` Python package.